### PR TITLE
Allow $ as a valid JSON path and reference path

### DIFF
--- a/lib/j2119/json_path_checker.rb
+++ b/lib/j2119/json_path_checker.rb
@@ -42,8 +42,8 @@ module J2119
     index = '((' + num_index + ')|(' + star_index + ')|(' + colon_index + '))'
     step = '((' + dot_step + ')|(' + bracket_step + ')|(' + index + '))' + '(' + index + ')?'
     rp_step = '((' + rp_dot_step + ')|(' + bracket_step + '))' + '(' + rp_num_index + ')?'
-    path = '^\$' + '(' + step + ')+$'
-    reference_path = '^\$' + '(' + rp_step + ')+$'
+    path = '^\$' + '(' + step + ')*$'
+    reference_path = '^\$' + '(' + rp_step + ')*$'
     @@path_re = Regexp.new(path)
     @@reference_path_re = Regexp.new(reference_path);
 

--- a/spec/json_path_checker_spec.rb
+++ b/spec/json_path_checker_spec.rb
@@ -17,6 +17,11 @@ require 'j2119/json_path_checker'
 
 describe J2119::JSONPathChecker do
 
+  it 'should allow default paths' do
+    expect(J2119::JSONPathChecker.is_path?('$')).to be_truthy
+    expect(J2119::JSONPathChecker.is_reference_path?('$')).to be_truthy
+  end
+
   it 'should do simple paths' do
     expect(J2119::JSONPathChecker.is_path?('$.foo.bar')).to be_truthy
     expect(J2119::JSONPathChecker.is_path?('$..x')).to be_truthy


### PR DESCRIPTION
The regexes for JSONPaths and ReferencePaths expect $(something), when $ is fine too.  Tweaking the quantifier from + to * resolves this problem.

This addresses awslabs/statelint#18