### PR TITLE
Untyped, object, and array field contents

### DIFF
--- a/lib/j2119/allowed_fields.rb
+++ b/lib/j2119/allowed_fields.rb
@@ -19,6 +19,7 @@ module J2119
 
     def initialize
       @allowed = {}
+      @any = []
     end
 
     def set_allowed(role, child)
@@ -26,9 +27,19 @@ module J2119
       @allowed[role] << child
     end
 
+    def set_any(role)
+      @any << role
+    end
+
     def allowed?(roles, child)
-      roles.any? do |role|
+      any?(roles) || roles.any? do |role|
         @allowed[role] && @allowed[role].include?(child)
+      end
+    end
+
+    def any?(roles)
+      roles.any? do |role|
+        @any.include?(role)
       end
     end
   end

--- a/lib/j2119/assigner.rb
+++ b/lib/j2119/assigner.rb
@@ -118,13 +118,13 @@ module J2119
         elsif child_type == 'element' || child_type == 'field'
           @roles.add_grandchild_role(role, field_name, assertion['child_role'])
         end
-      end
-
-
-      # untyped field without a defined child role
-      if field_name && !type && !child_type && modal != 'MUST NOT'
-        @roles.add_grandchild_role(role, field_name, field_name)
-        @allowed_fields.set_any(field_name)
+      else
+        anyOrObjectOrArray = !type || type == 'object' || type == 'array'
+        # untyped field without a defined child role
+        if field_name && anyOrObjectOrArray && modal != 'MUST NOT'
+          @roles.add_grandchild_role(role, field_name, field_name)
+          @allowed_fields.set_any(field_name)
+        end
       end
     end
 

--- a/lib/j2119/assigner.rb
+++ b/lib/j2119/assigner.rb
@@ -58,6 +58,7 @@ module J2119
       relation = assertion['relation']
       target = assertion['target']
       strings = assertion['strings']
+      child_type = assertion['child_type']
       vals = assertion['vals']
 
       # watch out for conditionals
@@ -110,14 +111,20 @@ module J2119
       end
       
       # there can be role defs there too
-      if assertion['child_type']
+      if child_type
         @matcher.add_role assertion['child_role']
-        child_type = assertion['child_type']
         if child_type == 'value'
           @roles.add_child_role(role, field_name, assertion['child_role'])
         elsif child_type == 'element' || child_type == 'field'
           @roles.add_grandchild_role(role, field_name, assertion['child_role'])
         end
+      end
+
+
+      # untyped field without a defined child role
+      if field_name && !type && !child_type && modal != 'MUST NOT'
+        @roles.add_grandchild_role(role, field_name, field_name)
+        @allowed_fields.set_any(field_name)
       end
     end
 

--- a/lib/j2119/assigner.rb
+++ b/lib/j2119/assigner.rb
@@ -119,9 +119,9 @@ module J2119
           @roles.add_grandchild_role(role, field_name, assertion['child_role'])
         end
       else
-        anyOrObjectOrArray = !type || type == 'object' || type == 'array'
+        anyOrObjectOrArray = (!type) || (type == 'object') || (type == 'array')
         # untyped field without a defined child role
-        if field_name && anyOrObjectOrArray && modal != 'MUST NOT'
+        if field_name && anyOrObjectOrArray && (modal != 'MUST NOT')
           @roles.add_grandchild_role(role, field_name, field_name)
           @allowed_fields.set_any(field_name)
         end

--- a/lib/j2119/node_validator.rb
+++ b/lib/j2119/node_validator.rb
@@ -56,21 +56,21 @@ module J2119
 
         # find inheritance-based roles for that field
         grandchild_roles = @parser.find_grandchild_roles(roles, name)
-
-        # recurse into grandkids
-        if val.is_a? Hash
-          val.each do |child_name, child_val|
-            validate_node(child_val, "#{path}.#{name}.#{child_name}",
-                          grandchild_roles.clone, problems)
+        if !@parser.allows_any?(grandchild_roles)
+          # recurse into grandkids
+          if val.is_a? Hash
+            val.each do |child_name, child_val|
+              validate_node(child_val, "#{path}.#{name}.#{child_name}",
+                            grandchild_roles.clone, problems)
+            end
+          elsif val.is_a? Array
+            i = 0
+            val.each do |member|
+              validate_node(member, "#{path}.#{name}[#{i}]",
+                            grandchild_roles.clone, problems)
+              i += 1
+            end
           end
-        elsif val.is_a? Array
-          i = 0
-          val.each do |member|
-            validate_node(member, "#{path}.#{name}[#{i}]",
-                          grandchild_roles.clone, problems)
-            i += 1
-          end
-          
         end
       end
     end

--- a/lib/j2119/parser.rb
+++ b/lib/j2119/parser.rb
@@ -97,5 +97,9 @@ module J2119
     def field_allowed?(roles, child)
       @allowed_fields.allowed?(roles, child)
     end
+
+    def allows_any?(roles)
+      @allowed_fields.any?(roles)
+    end
   end
 end

--- a/spec/node_validator_spec.rb
+++ b/spec/node_validator_spec.rb
@@ -80,5 +80,9 @@ describe J2119::NodeValidator do
     def field_allowed?(r, f)
       true
     end
+
+    def allows_any?(f)
+      false
+    end
 end
 end

--- a/spec/validator_spec.rb
+++ b/spec/validator_spec.rb
@@ -25,6 +25,44 @@ GOOD = '{ ' +
        ' } ' +
        '}'
 
+WITH_ARRAY_RESULT =
+       '{ ' +
+       ' "StartAt": "No-op", ' +
+       ' "States": { ' +
+       '  "No-op": { ' +
+       '   "Type": "Pass", ' +
+       '   "ResultPath": "$.coords", ' +
+       '   "Result": [ ' +
+       '    "foo", ' +
+       '    "bar", ' +
+       '    { ' +
+       '     "bazz": 123 ' +
+       '    } ' +
+       '   ], ' +
+       '   "End": true ' +
+       '  } ' +
+       ' } ' +
+       '} '
+
+WITH_OBJECT_RESULT =
+    '{ ' +
+        ' "StartAt": "No-op", ' +
+        ' "States": { ' +
+        '  "No-op": { ' +
+        '   "Type": "Pass", ' +
+        '   "ResultPath": "$.coords", ' +
+        '   "Result": { ' +
+        '    "foo": { ' +
+        '     "x-datum": 0.381018, ' +
+        '     "y-datum": 622.2269926397355 ' +
+        '    } ' +
+        '   }, ' +
+        '   "End": true ' +
+        '  } ' +
+        ' } ' +
+        '} '
+
+
 SCHEMA = File.dirname(__FILE__) + '/../data/AWL.j2119'
 
 describe J2119::Validator do
@@ -59,5 +97,19 @@ describe J2119::Validator do
     p = v.validate GOOD + 'x'
     expect(p.size).to eq(1)
   end
-  
+
+  it 'should allow Result to have array value' do
+    v = J2119::Validator.new SCHEMA
+    p = v.validate WITH_ARRAY_RESULT
+    p.each {|problem| puts "P: #{problem}"}
+    expect(p.size).to eq(0)
+  end
+
+  it 'should allow Result to have object value' do
+    v = J2119::Validator.new SCHEMA
+    p = v.validate WITH_OBJECT_RESULT
+    p.each {|problem| puts "P: #{problem}"}
+    expect(p.size).to eq(0)
+  end
+
 end


### PR DESCRIPTION
j2119 is an exhaustive validator, so it traverses the entire JSON tree applying its rules.  This is not always appropriate. For example in the case of a rule like 
  ```A Pass State MAY have a field named "Result".```
the Result field content's are, by definition, ok and so further validation rules should not be applied.

This PR makes this change for rules of the form
  ```An Any MAY have a field named "Any".```
  ```A Whatever MAY have an object field named "Obj".```
  ```A List MAY have an array field named "Array".```
ie Untyped, object, or array fields without a defined child type which may or must be present.

Object and array fields contents must be of the appropriate type, but further contents validation is not applied.  

This address awslabs/statelint#15
