### PR TITLE
reference github in gemspec

### DIFF
--- a/j2119.gemspec
+++ b/j2119.gemspec
@@ -9,7 +9,15 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files`.split("\n").reject do |f|
     f.match(%r{^(spec|data)/})
   end
-  s.homepage    = 'http://rubygems.org/gems/j2119'
+  s.homepage    = 'https://github.com/awslabs/j2119'
   s.license     = 'Apache 2.0'
+
+  s.required_ruby_version = '>= 1.9.2'
+
   s.add_runtime_dependency "json"
+
+  s.metadata = {
+    'source_code_uri' => 'https://github.com/awslabs/j2119',
+    "bug_tracker_uri"   => 'https://github.com/awslabs/j2119/issues'
+  }
 end


### PR DESCRIPTION
Hello, Thank you for your work with the state language.

## Issue #, if available:


## Description of changes:

Ruby gems does not reference https://rubygems.org/gems/j2119
People have to google around to get here.

I used statelint's gemspec as a template.

## Release

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
